### PR TITLE
Fixed broken upload in Firefox

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -15,7 +15,7 @@ function prepareUpload(event){
 }
 
 
-function uploadFiles(){
+function uploadFiles(event){
     event.stopPropagation();
     event.preventDefault();
 


### PR DESCRIPTION
Added 'event' argument to uploadFiles() to pass it to the function.
Before it broke with 'ReferenceError: event is not defined'.