### PR TITLE
Fix the exception thrown when a route other than base route is opened

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 
-from flask import Flask, request, render_template, jsonify
+from flask import Flask, request, render_template, jsonify, redirect, url_for
 
 from utils import get_parsed_file
 
@@ -37,13 +37,16 @@ def main():
     ctx = {
         'is_prod': IS_PROD
     }
-    return render_template("index.html", data=ctx)
+    if request.args.get('redirect'):
+        message = "Sorry, we couldn't find the page"
+        return render_template("index.html", data=ctx, error_message=message)
+    else:
+        return render_template("index.html", data=ctx)
 
 
 @app.errorhandler(404)
 def not_found(e):
-    message = "404 We couldn't find the page"
-    return render_template("index.html", error_message=message)
+    return redirect(url_for('main', redirect='home'))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Whenever any route other than the base route is opened, the page will get redirected to the base route, along with the error message, passed as an argument to the base template.