### PR TITLE
Fix #70

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -20,7 +20,7 @@ def _get_parsed_line(input_line, persons_list):
             timestamp_string = parse_datetime(dirty_timestamp_string, dayfirst=True)
             line = timestamp_splitter.join(items[1:]).strip()
             break
-        except ValueError:
+        except (ValueError, OverflowError):
             continue
     if not timestamp_string:
         raise IndexError


### PR DESCRIPTION
Hi,
I found your WA Reader and found it very useful already. I noticed Issue #70, as I saw it during the upload of a chat with ~ 4000 lines. But after investigating on which line it actually breaks, I found that in that chat someone posted a joke of binary text.
If you eg. create a chat file like:
...
13/10/2017, 12:12 a.m. - The Joker: Let's not BLOW this out of proportion.
13/10/2017, 12:12 a.m. - Gambol: You think you can steal from us and just walk away?  
00001100110000111100010101111111000001111000  
13/10/2017, 12:12 a.m. - The Joker: Yeah.
...
(yes, there is a line break starting the new line with only text or here numbers)
The dateutil.parser parser tries to find some date in it and fails on the message: OverflowError: Python int too large to convert to C long in
Sample code to prove:
`from dateutil.parser import parse
dt = parse('Sun, 05/12/1999, 12:30PM')
print(dt.date())
dt = parse('00001100110000111100010101111111000001111000')
print(dt.date())`

I added a line to the utils.py to catch this error as well. In the Issue #70 you already mentioned some weird chars. Maybe this happens also in case of some unicode chars? 

regards